### PR TITLE
Wall item placement convenience tool

### DIFF
--- a/NHSE.Core/Structures/Map/Layers/ItemLayer.cs
+++ b/NHSE.Core/Structures/Map/Layers/ItemLayer.cs
@@ -167,6 +167,15 @@ namespace NHSE.Core
             return PlacedItemPermission.NoCollision;
         }
 
+        /// <summary>
+        /// Checks if specified coordinates fall within the limits of the grid
+        /// </summary>
+        /// <returns>True if coords are in a valid grid location, false otherwise</returns>
+        public bool IsCoordWithinGrid(int x, int y)
+        {
+            return x < MaxWidth && y < MaxHeight;
+        }
+
         public int ReplaceAll(Item oldItem, Item newItem, in int xmin, in int ymin, in int width, in int height)
         {
             var sizeOld = ItemInfo.GetItemSize(oldItem);

--- a/NHSE.WinForms/Controls/ItemEditor.cs
+++ b/NHSE.WinForms/Controls/ItemEditor.cs
@@ -57,6 +57,8 @@ namespace NHSE.WinForms
 
             AllItems = items;
 
+            var test = items.Where(x => x.Value == 02596);
+
             List<ComboItem> itemKinds = new List<ComboItem>
             {
                 new ("None", -1)
@@ -244,7 +246,7 @@ namespace NHSE.WinForms
                     break;
 
                 case ItemKind.Kind_DIYRecipe:
-                    CB_Recipe.SelectedValue = (int)NUD_Count.Value;
+                    CB_Recipe.SelectedValue = (int) NUD_Count.Value;
                     break;
 
                 case ItemKind.Kind_MessageBottle:

--- a/NHSE.WinForms/Subforms/Map/FieldItemEditor.Designer.cs
+++ b/NHSE.WinForms/Subforms/Map/FieldItemEditor.Designer.cs
@@ -968,7 +968,7 @@
             // L_PlazaX
             // 
             this.L_PlazaX.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
-            this.L_PlazaX.Location = new System.Drawing.Point(-39, -766);
+            this.L_PlazaX.Location = new System.Drawing.Point(65, 2);
             this.L_PlazaX.Name = "L_PlazaX";
             this.L_PlazaX.Size = new System.Drawing.Size(62, 20);
             this.L_PlazaX.TabIndex = 115;
@@ -978,7 +978,7 @@
             // NUD_PlazaX
             // 
             this.NUD_PlazaX.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
-            this.NUD_PlazaX.Location = new System.Drawing.Point(24, -765);
+            this.NUD_PlazaX.Location = new System.Drawing.Point(128, 3);
             this.NUD_PlazaX.Maximum = new decimal(new int[] {
             1024,
             0,
@@ -997,7 +997,7 @@
             // L_PlazaY
             // 
             this.L_PlazaY.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
-            this.L_PlazaY.Location = new System.Drawing.Point(-39, -745);
+            this.L_PlazaY.Location = new System.Drawing.Point(65, 23);
             this.L_PlazaY.Name = "L_PlazaY";
             this.L_PlazaY.Size = new System.Drawing.Size(62, 20);
             this.L_PlazaY.TabIndex = 113;
@@ -1007,7 +1007,7 @@
             // NUD_PlazaY
             // 
             this.NUD_PlazaY.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
-            this.NUD_PlazaY.Location = new System.Drawing.Point(24, -744);
+            this.NUD_PlazaY.Location = new System.Drawing.Point(128, 24);
             this.NUD_PlazaY.Maximum = new decimal(new int[] {
             1024,
             0,
@@ -1026,7 +1026,7 @@
             // B_Help
             // 
             this.B_Help.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
-            this.B_Help.Location = new System.Drawing.Point(22, -355);
+            this.B_Help.Location = new System.Drawing.Point(126, 413);
             this.B_Help.Name = "B_Help";
             this.B_Help.Size = new System.Drawing.Size(112, 40);
             this.B_Help.TabIndex = 111;
@@ -1036,13 +1036,13 @@
             // 
             // LB_Items
             // 
-            this.LB_Items.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
-            | System.Windows.Forms.AnchorStyles.Left) 
+            this.LB_Items.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom)
+            | System.Windows.Forms.AnchorStyles.Left)
             | System.Windows.Forms.AnchorStyles.Right)));
             this.LB_Items.FormattingEnabled = true;
             this.LB_Items.Location = new System.Drawing.Point(6, 45);
             this.LB_Items.Name = "LB_Items";
-            this.LB_Items.Size = new System.Drawing.Size(128, 4);
+            this.LB_Items.Size = new System.Drawing.Size(232, 186);
             this.LB_Items.TabIndex = 109;
             this.LB_Items.SelectedIndexChanged += new System.EventHandler(this.LB_Items_SelectedIndexChanged);
             // 
@@ -1118,12 +1118,12 @@
             // 
             // PG_TerrainTile
             // 
-            this.PG_TerrainTile.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            this.PG_TerrainTile.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left)
             | System.Windows.Forms.AnchorStyles.Right)));
             this.PG_TerrainTile.Location = new System.Drawing.Point(3, 3);
             this.PG_TerrainTile.Name = "PG_TerrainTile";
             this.PG_TerrainTile.PropertySort = System.Windows.Forms.PropertySort.Categorized;
-            this.PG_TerrainTile.Size = new System.Drawing.Size(134, 266);
+            this.PG_TerrainTile.Size = new System.Drawing.Size(238, 266);
             this.PG_TerrainTile.TabIndex = 41;
             this.PG_TerrainTile.ToolbarVisible = false;
             // 

--- a/NHSE.WinForms/Subforms/Map/FieldItemEditor.Designer.cs
+++ b/NHSE.WinForms/Subforms/Map/FieldItemEditor.Designer.cs
@@ -158,6 +158,7 @@
             this.CHK_RedirectExtensionLoad = new System.Windows.Forms.CheckBox();
             this.CHK_MoveOnDrag = new System.Windows.Forms.CheckBox();
             this.CHK_FieldItemSnap = new System.Windows.Forms.CheckBox();
+            this.CHK_WallPlace = new System.Windows.Forms.CheckBox();
             this.CM_Click.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.PB_Map)).BeginInit();
             this.CM_Picture.SuspendLayout();
@@ -967,7 +968,7 @@
             // L_PlazaX
             // 
             this.L_PlazaX.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
-            this.L_PlazaX.Location = new System.Drawing.Point(65, 2);
+            this.L_PlazaX.Location = new System.Drawing.Point(-39, -766);
             this.L_PlazaX.Name = "L_PlazaX";
             this.L_PlazaX.Size = new System.Drawing.Size(62, 20);
             this.L_PlazaX.TabIndex = 115;
@@ -977,7 +978,7 @@
             // NUD_PlazaX
             // 
             this.NUD_PlazaX.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
-            this.NUD_PlazaX.Location = new System.Drawing.Point(128, 3);
+            this.NUD_PlazaX.Location = new System.Drawing.Point(24, -765);
             this.NUD_PlazaX.Maximum = new decimal(new int[] {
             1024,
             0,
@@ -996,7 +997,7 @@
             // L_PlazaY
             // 
             this.L_PlazaY.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
-            this.L_PlazaY.Location = new System.Drawing.Point(65, 23);
+            this.L_PlazaY.Location = new System.Drawing.Point(-39, -745);
             this.L_PlazaY.Name = "L_PlazaY";
             this.L_PlazaY.Size = new System.Drawing.Size(62, 20);
             this.L_PlazaY.TabIndex = 113;
@@ -1006,7 +1007,7 @@
             // NUD_PlazaY
             // 
             this.NUD_PlazaY.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
-            this.NUD_PlazaY.Location = new System.Drawing.Point(128, 24);
+            this.NUD_PlazaY.Location = new System.Drawing.Point(24, -744);
             this.NUD_PlazaY.Maximum = new decimal(new int[] {
             1024,
             0,
@@ -1025,7 +1026,7 @@
             // B_Help
             // 
             this.B_Help.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
-            this.B_Help.Location = new System.Drawing.Point(126, 413);
+            this.B_Help.Location = new System.Drawing.Point(22, -355);
             this.B_Help.Name = "B_Help";
             this.B_Help.Size = new System.Drawing.Size(112, 40);
             this.B_Help.TabIndex = 111;
@@ -1041,7 +1042,7 @@
             this.LB_Items.FormattingEnabled = true;
             this.LB_Items.Location = new System.Drawing.Point(6, 45);
             this.LB_Items.Name = "LB_Items";
-            this.LB_Items.Size = new System.Drawing.Size(232, 186);
+            this.LB_Items.Size = new System.Drawing.Size(128, 4);
             this.LB_Items.TabIndex = 109;
             this.LB_Items.SelectedIndexChanged += new System.EventHandler(this.LB_Items_SelectedIndexChanged);
             // 
@@ -1122,7 +1123,7 @@
             this.PG_TerrainTile.Location = new System.Drawing.Point(3, 3);
             this.PG_TerrainTile.Name = "PG_TerrainTile";
             this.PG_TerrainTile.PropertySort = System.Windows.Forms.PropertySort.Categorized;
-            this.PG_TerrainTile.Size = new System.Drawing.Size(238, 266);
+            this.PG_TerrainTile.Size = new System.Drawing.Size(134, 266);
             this.PG_TerrainTile.TabIndex = 41;
             this.PG_TerrainTile.ToolbarVisible = false;
             // 
@@ -1280,6 +1281,7 @@
             // 
             // Tab_Placement
             // 
+            this.Tab_Placement.Controls.Add(this.CHK_WallPlace);
             this.Tab_Placement.Controls.Add(this.CHK_Flag4);
             this.Tab_Placement.Controls.Add(this.NUD_DropRows);
             this.Tab_Placement.Controls.Add(this.L_DropRows);
@@ -1499,6 +1501,17 @@
             this.CHK_FieldItemSnap.Text = "Snap Field Items to Grid on Set";
             this.CHK_FieldItemSnap.UseVisualStyleBackColor = true;
             // 
+            // CHK_WallPlace
+            // 
+            this.CHK_WallPlace.AutoSize = true;
+            this.CHK_WallPlace.CheckAlign = System.Drawing.ContentAlignment.MiddleRight;
+            this.CHK_WallPlace.Location = new System.Drawing.Point(52, 60);
+            this.CHK_WallPlace.Name = "CHK_WallPlace";
+            this.CHK_WallPlace.Size = new System.Drawing.Size(125, 17);
+            this.CHK_WallPlace.TabIndex = 3;
+            this.CHK_WallPlace.Text = "Place root as #5656:";
+            this.CHK_WallPlace.UseVisualStyleBackColor = true;
+            // 
             // FieldItemEditor
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
@@ -1706,5 +1719,6 @@
         private System.Windows.Forms.Label L_DropRows;
         private System.Windows.Forms.CheckBox CHK_Flag4;
         private System.Windows.Forms.ToolStripMenuItem B_BuryItems;
+        private System.Windows.Forms.CheckBox CHK_WallPlace;
     }
 }

--- a/NHSE.WinForms/Subforms/Map/FieldItemEditor.cs
+++ b/NHSE.WinForms/Subforms/Map/FieldItemEditor.cs
@@ -408,6 +408,12 @@ namespace NHSE.WinForms
                 x += Math.Max((w / 2) - 1, 0);
                 y += Math.Max((h / 2) - 1, 0);
                 tile = l.GetTile(x, y);
+            } 
+            else if (CHK_WallPlace.Checked && pgt.SystemParam == 0x0)
+            {
+                pgt.UseCount = pgt.Count;
+                pgt.Count = pgt.DisplayItemId;
+                pgt.ItemId = 5656;
             }
 
             if (pgt.IsFieldItem && CHK_FieldItemSnap.Checked)
@@ -439,11 +445,14 @@ namespace NHSE.WinForms
             if (reload) ReloadItems();
         }
 
+
         // TODO: Implement direction
         private void SetDroppedTiles(int x, int y, int count = -1, bool reload = true)
         {
             var item = new Item();
+            var l = Map.CurrentLayer; // I don't like this being here, but we need it for the bounds check for now...
             ItemEdit.SetItem(item);
+
             if (item.IsBuried && CHK_Flag4.Checked)
             {
                 // Pretend we're a full item for size related purposes if aimbot is on
@@ -451,16 +460,32 @@ namespace NHSE.WinForms
             }
             var w = ItemInfo.GetItemSize(item).GetWidth();
             var h = ItemInfo.GetItemSize(item).GetHeight();
+
+            if (item.SystemParam == 0x0 && CHK_WallPlace.Checked)
+            {
+                var copy = new Item(5656);
+                w = ItemInfo.GetItemSize(copy).GetWidth();
+                h = ItemInfo.GetItemSize(copy).GetHeight();
+            }
             // Force even number
             w += w % 2;
             h += h % 2;
 
-            for (int j = 0; j < NUD_DropRows.Value; j++)
+            for (var j = 0; j < NUD_DropRows.Value; j++)
             {
-                for (var i = 0; i < w / 2; i++)
+                var newY = y + h + 2 * j;
+                if (l.IsCoordWithinGrid(x + (w / 2 - 1) * 2, newY))
                 {
-                    var tile = Map.CurrentLayer.GetTile(x + i * 2, y + h + 2 * j);
-                    SetTile(tile, x + i * 2, y + h + 2 * j, 0x20, count, false);
+                    for (var i = 0; i < w / 2; i++)
+                    {
+                        var newX = x + i * 2;
+                        var tile = Map.CurrentLayer.GetTile(newX, newY);
+                        SetTile(tile, newX, newY, 0x20, count, true);
+                    }
+                }
+                else
+                {
+                    break;
                 }
             }
 
@@ -478,6 +503,11 @@ namespace NHSE.WinForms
                 itemCopy.CopyFrom(item);
                 itemCopy.SystemParam = 0x0;
                 size = ItemInfo.GetItemSize(itemCopy);
+            }
+            else if (item.SystemParam == 0x0 && CHK_WallPlace.Checked)
+            {
+                var copy = new Item(5656);
+                size = ItemInfo.GetItemSize(copy);
             }
             else
             {

--- a/NHSE.WinForms/Subforms/Map/FieldItemEditor.resx
+++ b/NHSE.WinForms/Subforms/Map/FieldItemEditor.resx
@@ -207,6 +207,9 @@
   <metadata name="B_DumpLoadBuildings.Locked" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
+  <metadata name="CM_DLBuilding.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>930, 17</value>
+  </metadata>
   <metadata name="L_Bit.Locked" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
@@ -324,141 +327,6 @@
   <metadata name="B_DumpLoadAcres.Locked" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
-  <metadata name="L_MapAcre.Locked" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>True</value>
-  </metadata>
-  <metadata name="CB_MapAcre.Locked" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>True</value>
-  </metadata>
-  <metadata name="Tab_Placement.Locked" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>True</value>
-  </metadata>
-  <metadata name="CHK_Flag4.Locked" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>True</value>
-  </metadata>
-  <metadata name="NUD_DropRows.Locked" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>True</value>
-  </metadata>
-  <metadata name="L_DropRows.Locked" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>True</value>
-  </metadata>
-  <metadata name="B_DumpLoadBuildings.Locked" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>True</value>
-  </metadata>
-  <metadata name="CM_DLBuilding.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>930, 17</value>
-  </metadata>
-  <metadata name="L_Bit.Locked" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>True</value>
-  </metadata>
-  <metadata name="NUD_Bit.Locked" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>True</value>
-  </metadata>
-  <metadata name="L_BuildingType.Locked" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>True</value>
-  </metadata>
-  <metadata name="NUD_BuildingType.Locked" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>True</value>
-  </metadata>
-  <metadata name="NUD_UniqueID.Locked" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>True</value>
-  </metadata>
-  <metadata name="L_BuildingX.Locked" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>True</value>
-  </metadata>
-  <metadata name="L_BuildingUniqueID.Locked" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>True</value>
-  </metadata>
-  <metadata name="NUD_X.Locked" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>True</value>
-  </metadata>
-  <metadata name="NUD_TypeArg.Locked" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>True</value>
-  </metadata>
-  <metadata name="L_BuildingY.Locked" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>True</value>
-  </metadata>
-  <metadata name="L_BuildingStructureArg.Locked" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>True</value>
-  </metadata>
-  <metadata name="NUD_Y.Locked" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>True</value>
-  </metadata>
-  <metadata name="NUD_Type.Locked" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>True</value>
-  </metadata>
-  <metadata name="L_BuildingRotation.Locked" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>True</value>
-  </metadata>
-  <metadata name="L_BuildingStructureType.Locked" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>True</value>
-  </metadata>
-  <metadata name="NUD_Angle.Locked" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>True</value>
-  </metadata>
-  <metadata name="L_PlazaX.Locked" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>True</value>
-  </metadata>
-  <metadata name="NUD_PlazaX.Locked" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>True</value>
-  </metadata>
-  <metadata name="L_PlazaY.Locked" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>True</value>
-  </metadata>
-  <metadata name="NUD_PlazaY.Locked" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>True</value>
-  </metadata>
-  <metadata name="B_Help.Locked" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>True</value>
-  </metadata>
-  <metadata name="LB_Items.Locked" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>True</value>
-  </metadata>
-  <metadata name="B_TerrainBrush.Locked" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>True</value>
-  </metadata>
-  <metadata name="L_TerrainTileLabelTransparency.Locked" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>True</value>
-  </metadata>
-  <metadata name="TR_Terrain.Locked" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>True</value>
-  </metadata>
-  <metadata name="TR_BuildingTransparency.Locked" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>True</value>
-  </metadata>
-  <metadata name="L_BuildingTransparency.Locked" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>True</value>
-  </metadata>
-  <metadata name="PG_TerrainTile.Locked" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>True</value>
-  </metadata>
-  <metadata name="L_FieldItemTransparency.Locked" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>True</value>
-  </metadata>
-  <metadata name="B_DumpLoadTerrain.Locked" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>True</value>
-  </metadata>
-  <metadata name="B_ModifyAllTerrain.Locked" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>True</value>
-  </metadata>
-  <metadata name="NUD_MapAcreTemplateField.Locked" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>True</value>
-  </metadata>
-  <metadata name="L_MapAcreTemplateField.Locked" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>True</value>
-  </metadata>
-  <metadata name="L_MapAcreTemplateOutside.Locked" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>True</value>
-  </metadata>
-  <metadata name="NUD_MapAcreTemplateOutside.Locked" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>True</value>
-  </metadata>
-  <metadata name="CB_MapAcreSelect.Locked" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>True</value>
-  </metadata>
-  <metadata name="B_DumpLoadAcres.Locked" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>True</value>
-  </metadata>
   <metadata name="CM_DLMapAcres.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>17, 56</value>
   </metadata>
@@ -466,6 +334,9 @@
     <value>True</value>
   </metadata>
   <metadata name="CB_MapAcre.Locked" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <metadata name="Tab_Placement.Locked" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
   <metadata name="CHK_Flag4.Locked" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">


### PR DESCRIPTION
Option to place root items as (Item #5656) holding the base item instead for convenient wall item placement.

Bugfix for crash caused by GetTile when submitting coordinates out of bounds caused by the dropped item placement loop.